### PR TITLE
Fixed symmetric/asymmetric graph typo/mismatch

### DIFF
--- a/AaDS_17/graph.tex
+++ b/AaDS_17/graph.tex
@@ -13,7 +13,7 @@ But they are needed because graph-structured data occurs very frequently.
 Practical examples of graph-structured data include
 \begin{compactitem}
  \item Social networks: nodes are given by people and edges by the social connection relation.
-  These relations may be symmetric (e.g., the follows-relation of twitter), which leads to directed graphs, or asymmetric (e.g., the are-friends-with-each-other relation of facebook), which leads to undirected graphs.
+  These relations may be asymmetric (e.g., the follows-relation of twitter), which leads to directed graphs, or symmetric (e.g., the are-friends-with-each-other relation of facebook), which leads to undirected graphs.
  \item Roads: nodes are given by cities and intersections and edges by roads between them. Flight routes, subway systems, etc. work accordingly.
  \item Utilities supply networks for water, electricity, internet, etc.: nodes are given by power plants/switchboards/hubs/etc. and households and edges by pipes/cables/etc.
  \item Mazes and other explorable territories: nodes are given by intersections and edges by paths.


### PR DESCRIPTION
The definitions for asymmetric and symmetric graphs were the wrong way
round.